### PR TITLE
removed incorrect parameter from worker method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ if (cluster.isMaster) {
 		workers[i] = cluster.fork();
 
 		// Optional: Restart worker on exit
-		workers[i].on('exit', function(worker, code, signal) {
+		workers[i].on('exit', function(code, signal) {
 			console.log('respawning worker', i);
 			spawn(i);
 		});


### PR DESCRIPTION
from workers[i].on('exit', function(...) does not return a worker object: https://nodejs.org/api/cluster.html#cluster_event_exit