### PR TITLE
Added farmhash to support IPv6. Added test for IPv6. Updated readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ var express = require('express'),
     cluster = require('cluster'),
     net = require('net'),
     sio = require('socket.io'),
-    sio_redis = require('socket.io-redis');
+    sio_redis = require('socket.io-redis'),
+    farmhash = require('farmhash');
 
 var port = 3000,
     num_processes = require('os').cpus().length;

--- a/README.md
+++ b/README.md
@@ -97,14 +97,7 @@ if (cluster.isMaster) {
 	// "real" IP number conversion, this function is on par in terms of
 	// worker index distribution only much faster.
 	var worker_index = function(ip, len) {
-		var s = '';
-		for (var i = 0, _len = ip.length; i < _len; i++) {
-			if (!isNaN(ip[i])) {
-				s += ip[i];
-			}
-		}
-
-		return Number(s) % len;
+		return farmhash.fingerprint32(ip[i]) % len; // Farmhash is the fastest and works with IPv6, too
 	};
 
 	// Create the outside facing server listening on our port.
@@ -165,18 +158,43 @@ Here's output from my machine:
 
 ```
 $ node benchmark 4
+IPv4
+----------
 benchmarking int31...
-  time (ms): 1827
-  scatter: { '0': 249998, '1': 250522, '2': 250015, '3': 249465 }
+  time (ms): 874
+  scatter: { '0': 249145, '1': 250189, '2': 249969, '3': 250697 }
 benchmarking numeric_real...
-  time (ms): 812
-  scatter: { '0': 249360, '1': 251027, '2': 250704, '3': 248909 }
+  time (ms): 441
+  scatter: { '0': 249084, '1': 251221, '2': 250609, '3': 249086 }
 benchmarking simple_regex...
-  time (ms): 480
-  scatter: { '0': 248367, '1': 249034, '2': 251697, '3': 250902 }
+  time (ms): 281
+  scatter: { '0': 247994, '1': 249241, '2': 251699, '3': 251066 }
 benchmarking simple_loop...
-  time (ms): 911
-  scatter: { '0': 248367, '1': 249034, '2': 251697, '3': 250902 }
+  time (ms): 559
+  scatter: { '0': 247994, '1': 249241, '2': 251699, '3': 251066 }
+benchmarking farmhash...
+  time (ms): 234
+  scatter: { '0': 249192, '1': 250640, '2': 250570, '3': 249598 }
+
+
+IPv6
+----------
+benchmarking int31...
+  time (ms): 418
+  scatter: { '0': 543029, '1': 143286, '2': 141239, '3': 172446 }
+benchmarking numeric_real...
+  time (ms): 821
+  scatter: { NaN: 1000000 }
+benchmarking simple_regex...
+  time (ms): 714
+  scatter: { NaN: 1000000 }
+benchmarking simple_loop...
+  time (ms): 1261
+  scatter: { '0': 890953, '1': 34728, '2': 38949, '3': 35370 }
+benchmarking farmhash...
+  time (ms): 314
+  scatter: { '0': 249034, '1': 250866, '2': 249923, '3': 250177 }
+
 $
 
 ```

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,58 +1,73 @@
+const farmhash = require('farmhash');
+const randomIpv6 = require('random-ipv6');
+
 function random_ip() {
-	return Math.round(Math.random()*255) + '.' +
-	       Math.round(Math.random()*255) + '.' +
-	       Math.round(Math.random()*255) + '.' +
-	       Math.round(Math.random()*255);
+    return Math.round(Math.random()*255) + '.' +
+        Math.round(Math.random()*255) + '.' +
+        Math.round(Math.random()*255) + '.' +
+        Math.round(Math.random()*255);
 }
 
 // Hash IP address using "Int31" algorithm from sticky-sessions.
 function hash_int31(ip, seed) {
-	var hash = ip.reduce(function(r, num) {
-		r += parseInt(num, 10);
-		r %= 2147483648;
-		r += (r << 10)
-		r %= 2147483648;
-		r ^= r >> 6;
-		return r;
-	}, seed);
+    var hash = ip.reduce(function(r, num) {
+        r += parseInt(num, 10);
+        r %= 2147483648;
+        r += (r << 10)
+        r %= 2147483648;
+        r ^= r >> 6;
+        return r;
+    }, seed);
 
-	hash += hash << 3;
-	hash %= 2147483648;
-	hash ^= hash >> 11;
-	hash += hash << 15;
-	hash %= 2147483648;
+    hash += hash << 3;
+    hash %= 2147483648;
+    hash ^= hash >> 11;
+    hash += hash << 15;
+    hash %= 2147483648;
 
-	return hash >>> 0;
+    return hash >>> 0;
 }
 
 // Convert IP address to true decimal representation.
 function hash_numeric_real(dot)  {
-	var d = dot.split('.');
-	return ((((((+d[0])*256)+(+d[1]))*256)+(+d[2]))*256)+(+d[3]);
+    var d = dot.split('.');
+    return ((((((+d[0])*256)+(+d[1]))*256)+(+d[2]))*256)+(+d[3]);
 }
 
 // Simple numeric representation, using a regex.
 function hash_simple_regex(ip) {
-	return Number(ip.replace(/\./g, ''));
+    return Number(ip.replace(/\./g, ''));
 };
 
 // Simple numeric representation, using a loop.
 function hash_simple_loop(ip) {
-	var s = '';
-	for (var i = 0, _len = ip.length; i < _len; i++) {
-		if (!isNaN(ip[i])) {
-			s += ip[i];
-		}
-	}
-	return Number(s);
+    var s = '';
+    for (var i = 0, _len = ip.length; i < _len; i++) {
+        if (!isNaN(ip[i])) {
+            s += ip[i];
+        }
+    }
+    return Number(s);
 };
+
+
+// IPv4
+//
 
 // Generate a lot of random IPs.
 var num_ips = 1000000,
-    ips = [];
+    ipsv4 = [];
+    ipsv6 = [];
+
+console.log('Generating ' + num_ips + ' IPs (IPv4)...');
 for (var i = 0; i < num_ips; i++) {
-	ips[i] = random_ip();
+    ipsv4[i] = random_ip();
 }
+console.log('Generating ' + num_ips + ' IPs (IPv6)...');
+for (var i = 0; i < num_ips; i++) {
+    ipsv6[i] = randomIpv6();
+}
+console.log('');
 
 // How many slots are available to us.
 var len = parseInt(process.argv[2]);
@@ -64,19 +79,23 @@ var seed = ~~(Math.random() * 1e9);
 var scatter_int31 = {},
     scatter_numeric_real = {},
     scatter_numeric_simple_regex = {},
-    scatter_numeric_simple_loop = {};
+    scatter_numeric_simple_loop = {},
+    scatter_numeric_farmhash = {};
 
 var t1, t2;
 
+console.log('IPv4');
+console.log('----------')
+
 console.log('benchmarking int31...');
 t1 = new Date();
-for (var i = 0; i < ips.length; i++) {
-	var index = hash_int31((ips[i] || '').split(/\./g), seed) % len;
-	if (!scatter_int31.hasOwnProperty(index)) {
-		scatter_int31[index] = 1;
-	} else {
-		scatter_int31[index]++;
-	}
+for (var i = 0; i < ipsv4.length; i++) {
+    var index = hash_int31((ipsv4[i] || '').split(/\./g), seed) % len;
+    if (!scatter_int31.hasOwnProperty(index)) {
+        scatter_int31[index] = 1;
+    } else {
+        scatter_int31[index]++;
+    }
 }
 t2 = new Date();
 console.log('  time (ms):', t2 - t1);
@@ -84,13 +103,13 @@ console.log('  scatter:', scatter_int31);
 
 console.log('benchmarking numeric_real...');
 t1 = new Date();
-for (var i = 0; i < ips.length; i++) {
-	var index = hash_numeric_real(ips[i]) % len;
-	if (!scatter_numeric_real.hasOwnProperty(index)) {
-		scatter_numeric_real[index] = 1;
-	} else {
-		scatter_numeric_real[index]++;
-	}
+for (var i = 0; i < ipsv4.length; i++) {
+    var index = hash_numeric_real(ipsv4[i]) % len;
+    if (!scatter_numeric_real.hasOwnProperty(index)) {
+        scatter_numeric_real[index] = 1;
+    } else {
+        scatter_numeric_real[index]++;
+    }
 }
 t2 = new Date();
 console.log('  time (ms):', t2 - t1);
@@ -98,13 +117,13 @@ console.log('  scatter:', scatter_numeric_real);
 
 console.log('benchmarking simple_regex...');
 t1 = new Date();
-for (var i = 0; i < ips.length; i++) {
-	var index = hash_simple_regex(ips[i]) % len;
-	if (!scatter_numeric_simple_regex.hasOwnProperty(index)) {
-		scatter_numeric_simple_regex[index] = 1;
-	} else {
-		scatter_numeric_simple_regex[index]++;
-	}
+for (var i = 0; i < ipsv4.length; i++) {
+    var index = hash_simple_regex(ipsv4[i]) % len;
+    if (!scatter_numeric_simple_regex.hasOwnProperty(index)) {
+        scatter_numeric_simple_regex[index] = 1;
+    } else {
+        scatter_numeric_simple_regex[index]++;
+    }
 }
 t2 = new Date();
 console.log('  time (ms):', t2 - t1);
@@ -112,14 +131,111 @@ console.log('  scatter:', scatter_numeric_simple_regex);
 
 console.log('benchmarking simple_loop...');
 t1 = new Date();
-for (var i = 0; i < ips.length; i++) {
-	var index = hash_simple_loop(ips[i]) % len;
-	if (!scatter_numeric_simple_loop.hasOwnProperty(index)) {
-		scatter_numeric_simple_loop[index] = 1;
-	} else {
-		scatter_numeric_simple_loop[index]++;
-	}
+for (var i = 0; i < ipsv4.length; i++) {
+    var index = hash_simple_loop(ipsv4[i]) % len;
+    if (!scatter_numeric_simple_loop.hasOwnProperty(index)) {
+        scatter_numeric_simple_loop[index] = 1;
+    } else {
+        scatter_numeric_simple_loop[index]++;
+    }
 }
 t2 = new Date();
 console.log('  time (ms):', t2 - t1);
 console.log('  scatter:', scatter_numeric_simple_loop);
+
+console.log('benchmarking farmhash...');
+t1 = new Date();
+for (var i = 0; i < ipsv4.length; i++) {
+    var index = farmhash.fingerprint32(ipsv4[i]) % len;
+    if (!scatter_numeric_farmhash.hasOwnProperty(index)) {
+        scatter_numeric_farmhash[index] = 1;
+    } else {
+        scatter_numeric_farmhash[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_numeric_farmhash);
+
+console.log('\n')
+
+// IPv6
+//
+scatter_int31 = {},
+    scatter_numeric_real = {},
+    scatter_numeric_simple_regex = {},
+    scatter_numeric_simple_loop = {},
+    scatter_numeric_farmhash = {};
+
+console.log('IPv6');
+console.log('----------');
+
+console.log('benchmarking int31...');
+t1 = new Date();
+for (var i = 0; i < ipsv6.length; i++) {
+    var index = hash_int31((ipsv6[i] || '').split(/\./g), seed) % len;
+    if (!scatter_int31.hasOwnProperty(index)) {
+        scatter_int31[index] = 1;
+    } else {
+        scatter_int31[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_int31);
+
+console.log('benchmarking numeric_real...');
+t1 = new Date();
+for (var i = 0; i < ipsv6.length; i++) {
+    var index = hash_numeric_real(ipsv6[i]) % len;
+    if (!scatter_numeric_real.hasOwnProperty(index)) {
+        scatter_numeric_real[index] = 1;
+    } else {
+        scatter_numeric_real[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_numeric_real);
+
+console.log('benchmarking simple_regex...');
+t1 = new Date();
+for (var i = 0; i < ipsv6.length; i++) {
+    var index = hash_simple_regex(ipsv6[i]) % len;
+    if (!scatter_numeric_simple_regex.hasOwnProperty(index)) {
+        scatter_numeric_simple_regex[index] = 1;
+    } else {
+        scatter_numeric_simple_regex[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_numeric_simple_regex);
+
+console.log('benchmarking simple_loop...');
+t1 = new Date();
+for (var i = 0; i < ipsv6.length; i++) {
+    var index = hash_simple_loop(ipsv6[i]) % len;
+    if (!scatter_numeric_simple_loop.hasOwnProperty(index)) {
+        scatter_numeric_simple_loop[index] = 1;
+    } else {
+        scatter_numeric_simple_loop[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_numeric_simple_loop);
+
+console.log('benchmarking farmhash...');
+t1 = new Date();
+for (var i = 0; i < ipsv6.length; i++) {
+    var index = farmhash.fingerprint32(ipsv6[i]) % len;
+    if (!scatter_numeric_farmhash.hasOwnProperty(index)) {
+        scatter_numeric_farmhash[index] = 1;
+    } else {
+        scatter_numeric_farmhash[index]++;
+    }
+}
+t2 = new Date();
+console.log('  time (ms):', t2 - t1);
+console.log('  scatter:', scatter_numeric_farmhash);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cluster-socket.io",
+  "main": "benchmark.js",
+  "dependencies": {
+    "farmhash": "^2.0.0",
+    "random-ipv6": "^1.0.2"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "start": "node benchmark.js"
+  }
+}


### PR DESCRIPTION
Currently ALL supplied hash-functions did not work with IPv6. Farmhash does not only outplay them with performance, but is the only one which supports IPv6. 